### PR TITLE
Fix issue with slider resetting to 0

### DIFF
--- a/discrete_slider/frontend/src/DiscreteSlider.tsx
+++ b/discrete_slider/frontend/src/DiscreteSlider.tsx
@@ -13,6 +13,8 @@ function createMarks(labels: string[]): any[] {
 }
 
 class DiscreteSlider extends StreamlitComponentBase {
+  state = { value: 0 }
+
   public render = (): ReactNode => {
     const vMargin = 7
     const hMargin = 20
@@ -27,6 +29,7 @@ class DiscreteSlider extends StreamlitComponentBase {
     return (
       <StyledSlider
         defaultValue={0}
+        value={this.state.value}
         min={0}
         max={options.length - 1}
         aria-labelledby="discrete-slider-restrict"
@@ -36,6 +39,7 @@ class DiscreteSlider extends StreamlitComponentBase {
         onChangeCommitted={(event, value) => {
           const selectedOption = options[Number(value)]
           Streamlit.setComponentValue(selectedOption)
+          this.setState({ value })
         }}
         disabled={this.props.disabled}
       />


### PR DESCRIPTION
This fixes the problem several have observed where the slider keeps resetting to 0.

Fixes: GH-1

I don't know why this is necessary, since @tconkling didn't seem to need it at the time he recorded his video. Perhaps some change in how the Material UI Slider works when it is uncontrolled? If anyone can explain why this is needed, I'd appreciate it!